### PR TITLE
Update underscore-keypath.js

### DIFF
--- a/lib/underscore-keypath.js
+++ b/lib/underscore-keypath.js
@@ -56,10 +56,10 @@
 
 	function toSegments(keypath) {
 		"use strict";
-		if (underscore.isArray(keyPath)) {
+		if (underscore.isArray(keypath)) {
 			return Array.prototype.slice.call(keypath);
 		}
-		if (underscore.isString(keyPath)) {
+		if (underscore.isString(keypath)) {
 			keypath = keypath.replace(/\.\./g, "«dot»");
 
 			// issue #1 https://github.com/jeeeyul/underscore-keypath/issues/1


### PR DESCRIPTION
Fixinig my typo with `keyPath` instead of `keypath`
